### PR TITLE
rewrite of manager.js

### DIFF
--- a/content/manager.js
+++ b/content/manager.js
@@ -1,16 +1,14 @@
 //root directory of managed files
 var tlsn_dir = getTLSNdir().path;
 //array of existing files
-var tlsn_files = []; //subdirectories of TLSNotary directory
+var tlsn_subdirs = []; //subdirectories of TLSNotary directory
 //keys are directory names (which have fixed format 
-//timestamp-server name), values are [tlsn OS.File object, boolean imported, table row index]:
+//timestamp-server name), values are:
+//[tlsn OS.File object, filehash, boolean imported, html table row object]:
 var tdict ={}; 
+//keep track of changes
+var tdict_prev = {};
 var tloaded = false;
-
-function importTLSNFiles(){
-	main.verify();
-	loadManager();
-}
 
 function tableRefresher(){
     if (!tloaded){
@@ -19,24 +17,52 @@ function tableRefresher(){
     }
     //table is ready to be drawn
     for (var d in tdict){
-	addNewRow(tdict[d][0],d,tdict[d][1],'tlsnotarygroup',"none");
-	verifyEntry(d, tdict[d][0].path);
+	if (!(d in tdict_prev)){
+	    //entirely new entry
+	    addNewRow(tdict[d][0],d,tdict[d][2],'none',"none","none");
+	    verifyEntry(d, tdict[d][0].path); //populates validation fields
+	}
+	else if (tdict[d][1].toString() != tdict_prev[d][1].toString()){
+	    //file is modified; reverify
+	    verifyEntry(d, tdict[d][0].path);
+	}
     }
     tloaded = false; //wait for next change
     setTimeout(tableRefresher, 500);
 }
 
+function importTLSNFile(){
+    main.verify(); //TODO if import fails due to unverified signature, there is no message to user.
+    loadManager();
+}
+
+
 function doRename(t){
+    var isValid=(function(){
+    var rg1=/^[^\\/:\*\?"<>\|]+$/; // forbidden characters \ / : * ? " < > |
+    var rg2=/^\./; // cannot start with dot (.)
+    var rg3=/^(nul|prn|con|lpt[0-9]|com[0-9])(\.|$)/i; // forbidden file names
+    return function isValid(fname){
+      return rg1.test(fname)&&!rg2.test(fname)&&!rg3.test(fname);
+    }
+    })();
     var new_name = window.prompt("Enter a new name for the notarization file:");
+    if(!(isValid(new_name))){
+	alert("Invalid filename");
+	return;
+    }
     if (!new_name.endsWith(".tlsn")){
 	new_name = new_name + ".tlsn";
     }
-    console.log("t.id is: "+t.id);
     basename = OS.Path.basename(t.id);
     original_path = t.id;
     basedir = OS.Path.dirname(t.id);
+    basedir_name = OS.Path.basename(basedir);
     //rename file on disk
     OS.File.move(original_path,OS.Path.join(basedir,new_name));
+    var row = tdict[basedir_name][3];
+    row.parentNode.removeChild(row);
+    delete tdict[basedir_name];
     loadManager();
 }
 
@@ -50,31 +76,39 @@ function addNewRow(fileEntry, dirname, imported,verified,verifier,html_link){
     let sname = dirname.substr(20);
     if (imported){ sname = sname.slice(0,-9);}
     tstamp = dirname.substr(0,19);
-    var tbody = document.getElementById("myTableData").getElementsByTagName('tbody')[0];
-    var rowCount = tbody.rows.length;
-    var row = tbody.insertRow(rowCount); 
-    tdict[dirname].push(rowCount); //sets the row index of this entry
-    row.insertCell(0).innerHTML =  fileEntry.name.slice(0,-5) + 
-    " <button id='" + fileEntry.path + "' style='float: right;' onclick='doRename(event.target)'> Rename </button>" +
-    " <button id='" + dirname + "' style='float: right;' onclick='doSave(event.target)'> Export </button>";
-    row.insertCell(1).innerHTML = tstamp + ' , ' + sname;
+    var row = tdict[dirname][3];
+    var x = jsonToDOM([ "td", {}, fileEntry.name.slice(0,-5)],document,{});
+    var y = jsonToDOM(["button",
+		{id: fileEntry.path,
+		 style: 'float: right',
+		 onclick: function (event){doRename(event.target);}
+		 }, "Rename"], document,{});
+    var z = jsonToDOM(["button",
+		{id: dirname,
+		 style: 'float: right',
+		 onclick: function (event){doSave(event.target);}
+		 }, "Export"], document,{});
+    x.appendChild(y);
+    x.appendChild(z);
+    row.appendChild(x);
+    row.appendChild(jsonToDOM([ "td", {}, tstamp + ' , ' + sname],document,{}));
     if (!imported){
-	row.insertCell(2).innerHTML = "mine";
+	row.appendChild(jsonToDOM([ "td", {}, "mine"],document,{}));
     }
     else {
-	row.insertCell(2).innerHTML = "imported";
+	row.appendChild(jsonToDOM([ "td", {}, "imported"],document,{}));
 	}
-    if (verified){
-	tbi = 'UNINITIALISED';
-    }
-    else {
-        tbi = 'NO';
-    }
-    row.insertCell(3).innerHTML = tbi;
-    row.insertCell(4).innerHTML = verifier;
-    row.insertCell(5).innerHTML = html_link;
-    button_html = "<button id='"+dirname+"' title='permanently remove this set of files from disk' onclick='deleteFile(event.target)'>Delete</button>";
-    row.insertCell(6).innerHTML = button_html;
+    row.appendChild(jsonToDOM([ "td", {}, verified],document,{}));
+    row.appendChild(jsonToDOM([ "td", {}, verifier],document,{}));
+    row.appendChild(jsonToDOM([ "td", {}, html_link],document,{}));
+    x = jsonToDOM([ "td", {}, ""],document,{});
+    y = jsonToDOM(["button",
+		{id: dirname,
+		 title: 'permanently remove this set of files from disk',
+		 onclick: function (event){deleteFile(event.target);}
+		 }, "Delete"], document,{});
+    x.appendChild(y);
+    row.appendChild(x);
 }
 
 
@@ -82,32 +116,18 @@ function deleteFile(basename){
 	var r = confirm("This will remove the entire directory:"+basename.id+", including html. Are you sure?");
 	if (r){
 	    OS.File.removeDir(OS.Path.join(tlsn_dir,basename.id));
+	    var row = tdict[basename.id][3];
+	    row.parentNode.removeChild(row);
+	    delete tdict[basename.id];
 	    loadManager();
 	}
 }
 
-function clearTable(){
-   tdict = {}
-   var table = document.getElementById("myTableData");
-   table.innerHTML = "<thead> \
-    <tr> \
-	<th title='Name of notarization file; click Rename to change the name to something more descriptive' scope='col' abbr='File'>File</th> \
-        <th title='date file was created and site name of the page' scope='col' abbr='Filename'>Creation date , server name</th> \
-        <th title='mine if the file was created by you, imported otherwise' scope='col' abbr='Date'>Mine/imported</th> \
-        <th title='whether the addon verifies that the contents are signed correctly' scope='col' abbr='Verified'>Verified</th> \
-	<th title='the identity of the verifying notary server' scope='col' abbr='Verifier'>Verifier</th> \
-	<th title='links to the html file on disk which is verified to come from the given site; raw shows the file in text' scope='col' abbr='Html'>View Html</th> \
-	<th title='permanently remove this notarized file from your system' scope='col' abbr='Delete'> </th> \
-    </tr>	\
-    </thead> \
-    <tbody> \
-	</tbody>";
-}
-
-//reloads whole file table, refreshing contents
 function loadManager() {
-   clearTable(); //resets tdict also 
-   tlsn_files = [];
+   //this function will rebuild the tdict and compare to the old version
+   tdict_prev = tdict;
+   tdict = {}  
+   tlsn_subdirs = [];
    tloaded = false;
   let iterator = new OS.File.DirectoryIterator(tlsn_dir);
   let promise = iterator.forEach(
@@ -116,29 +136,49 @@ function loadManager() {
 	    console.log("entry was not a directory, ignored:"+entry.path);
 	}
 	else {
-	    tlsn_files.push(entry);	    
+	    tlsn_subdirs.push(entry);	    
 	}    
     }
   );
-  
   promise.then(
     function onSuccess() {
       iterator.close();
-      for (var i=0; i < tlsn_files.length; i++){
+      for (var i=0; i < tlsn_subdirs.length; i++){
 	let imported = false;
-	if (tlsn_files[i].name.match("-IMPORTED$")=="-IMPORTED"){ 
+	if (tlsn_subdirs[i].name.match("-IMPORTED$")=="-IMPORTED"){ 
 	    imported = true;
 	}
-	var iterator2 = new OS.File.DirectoryIterator(tlsn_files[i].path);
+	var iterator2 = new OS.File.DirectoryIterator(tlsn_subdirs[i].path);
 	
 	let promise2 = iterator2.forEach(
 	function (entry2) {  
 	    if (entry2.path.endsWith(".tlsn")){
-		dirname = OS.Path.basename(OS.Path.dirname(entry2.path));
-		tdict[dirname]=[entry2, imported];
-		if (Object.keys(tdict).length == tlsn_files.length){
-		    tloaded = true;
-		}
+		OS.File.read(entry2.path).then(function (read_data){
+		    file_hash = sha256(read_data);
+		    dirname = OS.Path.basename(OS.Path.dirname(entry2.path));
+		    var row;
+		    if (!(dirname in tdict_prev)){
+			var tbody = document.getElementById("myTableData").getElementsByTagName('tbody')[0];
+			row = tbody.insertRow(tbody.rows.length); 
+		    }
+		    else {
+			row = tdict_prev[dirname][3];
+		    } 
+		    tdict[dirname]=[entry2, file_hash, imported, row];
+		    if (Object.keys(tdict).length == tlsn_subdirs.length){
+			//remove rows that refer to subdirs no longer existing 
+			//(will only happen if user manually deletes that subdirectory).
+			Array.prototype.diff = function(a) {
+			return this.filter(function(i) {return a.indexOf(i) < 0;});
+			};
+			var dict_diff = Object.keys(tdict_prev).diff(Object.keys(tdict));
+			for (var i=0; i<dict_diff.length; i++){
+			    var row = tdict_prev[dict_diff[i]][3];
+			    row.parentNode.removeChild(row);
+			}
+			tloaded = true;
+		    }
+		});
 	   }
 	});
 	promise2.then(
@@ -157,34 +197,137 @@ function loadManager() {
     });
 }
 
-function updateRow(basename, col, newval){
-	//TODO update multiple columns
-	var tbody = document.getElementById("myTableData").getElementsByTagName('tbody')[0];
-	var index = tdict[basename][2];
-	row = tbody.rows[index];
-	cell = row.cells[col];
-	cell.innerHTML = newval;
+function updateRow(basename, col, x){
+	cell = tdict[basename][3].cells[col];
+	parent = cell.parentNode;
+	new_element = jsonToDOM([ "td", {}, ""],document,{});
+	new_element.appendChild(x);
+	parent.insertBefore(new_element, cell);
+	parent.removeChild(cell);
 }
 
 function verifyEntry(basename, path){
-	console.log("About to read a file with path: "+path);
 	OS.File.read(path).then( function(imported_data){
-	verify_tlsn(imported_data);
+	    verify_tlsn(imported_data);
 	}).then(function (){
-	updateRow(basename,3,"<img src='chrome://tlsnotary/content/check.png' height='30' width='30' ></img> Valid");
-	//console.log("Pubkey: "+ba2hex(notary_pubkey));
-	updateRow(basename,4,"tlsnotarygroup"); //TODO: pretty print pubkey?
-	var html_link = getTLSNdir();
-	html_link.append(basename);
-	html_link.append('html.html');
-	block_urls.push(html_link.path);
-	updateRow(basename,5,"<a href = 'file://" + html_link.path + "'> view  </a> ,\
-	<a href = 'file://" + OS.Path.join(tlsn_dir,basename,"raw.txt") + "'> raw  </a>");
+	    displayVerification(basename, chosen_notary.name);
 	}).catch( function(error){
-	updateRow(basename,3,"<img src='chrome://tlsnotary/content/cross.png' height='30' width='30' ></img> Not verified: "+ error);
-	updateRow(basename,4,"none");
-	updateRow(basename,5,"none");
+	    log("Error in verifyEntry: "+error);
+	    var x = jsonToDOM([ "td", {}, ""],document,{});
+	    var y = jsonToDOM(["img",
+			{height: '30',
+			 width: '30',
+			 src: 'chrome://tlsnotary/content/cross.png',
+			 }, "Not verified"], document,{});
+	    var z = jsonToDOM([ "text", {}, " Not verified: "+error],document,{});
+	    x.appendChild(y);
+	    x.appendChild(z);
+	    updateRow(basename,3,x);
+	    x = jsonToDOM([ "td", {}, "none"],document,{});
+	    y = jsonToDOM([ "td", {}, "none"],document,{});
+	    updateRow(basename,4,x);
+	    updateRow(basename,5,y);
+
 	});	
+}
+
+function displayVerification(basename, notary_name){
+    var x = jsonToDOM([ "td", {}, ""],document,{});
+    var y = jsonToDOM(["img",
+	    {height: '30',
+	    width: '30',
+	    src: 'chrome://tlsnotary/content/check.png',
+	    }, "Valid"], document,{});
+    var z = jsonToDOM(["text",{}," valid"],document,{});
+    x.appendChild(y);
+    x.appendChild(z)
+    updateRow(basename,3,x);
+    x = jsonToDOM([ "td", {}, notary_name],document,{});
+    updateRow(basename,4,x); //TODO: pretty print pubkey?
+    var html_link = getTLSNdir();
+    html_link.append(basename);
+    html_link.append('html.html');
+    block_urls.push(html_link.path);
+    
+    x = jsonToDOM([ "td", {}, ""],document,{});
+    y = jsonToDOM(["a",
+	    {href: 'file://' + html_link.path,
+	    }, "view"], document,{});
+    var q = jsonToDOM(["text",{}," , "],document,{});
+    z = jsonToDOM(["a",
+	    {href: 'file://' + OS.Path.join(tlsn_dir,basename,"raw.txt"),
+	    }, "raw"], document,{});	    
+    x.appendChild(y);
+    x.appendChild(q);
+    x.appendChild(z);
+    updateRow(basename,5,x);
+}
+
+
+//The following code supports dynamically inserting
+//elements into the DOM
+jsonToDOM.namespaces = {
+    html: "http://www.w3.org/1999/xhtml",
+    xul: "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+};
+jsonToDOM.defaultNamespace = jsonToDOM.namespaces.html;
+
+function jsonToDOM(xml, doc, nodes) {
+    function namespace(name) {
+        var reElemNameParts = /^(?:(.*):)?(.*)$/.exec(name);
+        return { namespace: jsonToDOM.namespaces[reElemNameParts[1]], shortName: reElemNameParts[2] };
+    }
+
+    // Note that 'elemNameOrArray' is: either the full element name (eg. [html:]div) or an array of elements in JSON notation
+    function tag(elemNameOrArray, elemAttr) {
+        // Array of elements?  Parse each one...
+        if (Array.isArray(elemNameOrArray)) {
+            var frag = doc.createDocumentFragment();
+            Array.forEach(arguments, function(thisElem) {
+                frag.appendChild(tag.apply(null, thisElem));
+            });
+            return frag;
+        }
+
+        // Single element? Parse element namespace prefix (if none exists, default to defaultNamespace), and create element
+        var elemNs = namespace(elemNameOrArray);
+        var elem = doc.createElementNS(elemNs.namespace || jsonToDOM.defaultNamespace, elemNs.shortName);
+
+        // Set element's attributes and/or callback functions (eg. onclick)
+        for (var key in elemAttr) {
+            var val = elemAttr[key];
+            if (nodes && key == "key") {
+                nodes[val] = elem;
+                continue;
+            }
+
+            var attrNs = namespace(key);
+            if (typeof val == "function") {
+                // Special case for function attributes; don't just add them as 'on...' attributes, but as events, using addEventListener
+                elem.addEventListener(key.replace(/^on/, ""), val, false);
+            }
+            else {
+                // Note that the default namespace for XML attributes is, and should be, blank (ie. they're not in any namespace)
+                elem.setAttributeNS(attrNs.namespace || "", attrNs.shortName, val);
+            }
+        }
+
+        // Create and append this element's children
+        var childElems = Array.slice(arguments, 2);
+        childElems.forEach(function(childElem) {
+            if (childElem != null) {
+                elem.appendChild(
+                    typeof childElem == "object" ? tag.apply(null, childElem) :
+                        childElem instanceof doc.defaultView.Node ? childElem :
+                            doc.createTextNode(childElem)
+                );
+            }
+        });
+
+        return elem;
+    }
+
+    return tag.apply(null, xml);
 }
 
 tableRefresher();

--- a/content/manager.xhtml
+++ b/content/manager.xhtml
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="manager.css" type="text/css" media="screen"/>
 </head>
 <body onload="loadManager()">
-
+<script type="text/javascript;version=1.8" src="oracles.js"></script>
 <script  type="text/javascript;version=1.8" src="main.js"></script>
   <script type="text/javascript;version=1.8" src="CryptoJS/components/core.js"></script>
   <script type="text/javascript;version=1.8" src="CryptoJS/components/md5.js"></script>
@@ -25,26 +25,26 @@
   <script type="text/javascript;version=1.8" src="tlsn.js"></script>
   <script type="text/javascript;version=1.8" src="tlsn_utils.js"></script> 
   <script type="text/javascript;version=1.8" src="button.js"></script> 
-  <script type="text/javascript;version=1.8" src="oracles.js"></script> 
   <script type="text/javascript;version=1.8" src="manager.js"></script>
   
 <div id="mydata">
 <b>Existing notarization (.tlsn) files ...</b> 
 <button  id="refresher" onclick="loadManager()" title="refresh table"><em class="leftImage"></em>Refresh</button>
-<button id="import" onclick="importTLSNFiles()" title="import a .tlsn file from disk">Import</button>
+<button id="import" onclick="importTLSNFile()" title="import a .tlsn file from disk">Import</button>
 
-<table class="table1" id="myTableData">
-    <thead>
-    <tr>
-        <th scope="col" abbr="Filename">Filename</th>
-        <th scope="col" abbr="Date">File Details</th>
-        <th scope="col" abbr="Verified">Verified</th>
-	<th scope="col" abbr="Verifier">Verifier</th>
-	<th scope="col" abbr="Html">View Html</th>
+<table class="table1" id="myTableData">	
+    <thead> 
+    <tr> 
+	<th title='Name of notarization file; click Rename to change the name to something more descriptive' scope='col' abbr='File'>File</th> 
+        <th title='date file was created and site name of the page' scope='col' abbr='Filename'>Creation date , server name</th>
+        <th title='mine if the file was created by you, imported otherwise' scope='col' abbr='Date'>Mine/imported</th>
+        <th title='whether the addon verifies that the contents are signed correctly' scope='col' abbr='Verified'>Verified</th>
+	<th title='the identity of the verifying notary server' scope='col' abbr='Verifier'>Verifier</th>
+	<th title='links to the html file on disk which is verified to come from the given site; raw shows the file in text' scope='col' abbr='Html'>View Html</th>
+	<th title='permanently remove this notarized file from your system' scope='col' abbr='Delete'> </th>
     </tr>	
-    </thead>
-    
-    <tbody>
+    </thead> 
+    <tbody> 
 	</tbody>
 </table>
 </div>


### PR DESCRIPTION
Functionality all seems to be working, and no longer re-verifies unchanged files. If file import fails due to signature being invalid, there is currently no error message to user (i.e. nothing happens).

jsonToDOM is added to create / modify DOM elements instead of using innerHTML. User input for filenames is sanitized.
