### PR TITLE
fallback server allowed, preferences in about:addons, verifier server sh...

### DIFF
--- a/content/oracles.js
+++ b/content/oracles.js
@@ -56,7 +56,9 @@ var oracle =
 //there can be potentially multiple oracles to choose from
 var oracles = [];
 oracles.push(oracle);
-
+//all servers trusted to perform notary (including non-oracles)
+//TODO: configurable
+var pagesigner_servers = [oracle, waxwing];
 
 //assuming both events happened on the same day, get the time
 //difference between them in seconds

--- a/content/settings.xul
+++ b/content/settings.xul
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+
+
+<!DOCTYPE vbox SYSTEM "chrome://tlsnotary/locale/overlay.dtd">
+
+<window
+    xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+    width="1"
+    height="1"
+    onload="window.close();">   <!-- Close window if it gets opened directly for some reason -->
+  <setting pref="extensions.tlsnotary.fallback" type="string" title="Use fallback server (if oracle is not available)" />
+  <setting pref="extensions.tlsnotary.verbose" type="bool" title="Verbose logging" value="false" />
+</window>

--- a/install.rdf
+++ b/install.rdf
@@ -25,5 +25,7 @@
     <em:description>TLSNotary - prove an HTTPS page was in your browser</em:description>
     <em:creator>TLSNotary Group</em:creator>
     <em:homepageURL>https://tlsnotary.org</em:homepageURL>
+    <em:optionsURL>chrome://tlsnotary/content/settings.xul</em:optionsURL>
+    <em:optionsType>2</em:optionsType>
   </Description>      
 </RDF>


### PR DESCRIPTION
...own in table

Notes: extensions.tlsnotary.fallback is null by default, if set to anything, will currently pick only pagesigner_servers[1] (waxwing, the only test server). This could obv be extended and/or made user configurable.

Any file on disk which is verified by any server in the list pagesigner_oracles will be shown as verifier with the .name property of the oracle/server object shown in the table.

A settings.xul file makes the user settings .verbose and .fallback accessible from about:addons either via 'More' or via a Preferences button.